### PR TITLE
Fix: Group Management and Sharing

### DIFF
--- a/StudyGroupChat/app/build.gradle.kts
+++ b/StudyGroupChat/app/build.gradle.kts
@@ -55,11 +55,12 @@ dependencies {
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-//    implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
     // Image loading
     implementation("com.github.bumptech.glide:glide:4.16.0")
+    // QR code generation
+    implementation("com.journeyapps:zxing-android-embedded:4.3.0")
 
     // Activity KTX for viewModels()
     implementation("androidx.activity:activity-ktx:1.7.2")

--- a/StudyGroupChat/app/src/main/AndroidManifest.xml
+++ b/StudyGroupChat/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
 
     <application
         android:name=".StudyGroupChatApplication"
@@ -40,7 +42,14 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:windowSoftInputMode="adjustPan" />
+            android:windowSoftInputMode="adjustPan">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="studygroupchat" android:host="join" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".ui.LoginActivity"
             android:exported="false" />

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/adapter/RoomAdapter.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/adapter/RoomAdapter.kt
@@ -17,7 +17,8 @@ import java.time.format.DateTimeFormatter
 class RoomAdapter(
     private var roomList: List<Room>,
     private val isJoinRoom: Boolean,
-    private val onJoinClick: ((Room) -> Unit)? = null
+    private val onJoinClick: ((Room) -> Unit)? = null,
+    private val onItemClick: ((Room) -> Unit)? = null
 ) :  // true nếu ở JoinRoomFragment
     RecyclerView.Adapter<RoomAdapter.RoomViewHolder>() {
 
@@ -78,30 +79,32 @@ class RoomAdapter(
             holder.btnJoin.visibility = View.VISIBLE
             holder.btnJoin.setOnClickListener { onJoinClick?.invoke(room) }
 
+    } else {
+        val memberCount = room.members?.size
+        val ownerName = room.owner?.fullName ?: room.owner?.userName
+
+        if (memberCount != null && ownerName != null) {
+            holder.tvMember.text = "$ownerName • ${memberCount} thành viên"
+            holder.tvMember.visibility = View.VISIBLE
         } else {
-            val memberCount = room.members?.size
-            val ownerName = room.owner?.fullName ?: room.owner?.userName
-
-            if (memberCount != null && ownerName != null) {
-                holder.tvMember.text = "$ownerName • ${memberCount} thành viên"
-                holder.tvMember.visibility = View.VISIBLE
-            } else {
-                holder.tvMember.visibility = View.GONE
-            }
-
-            holder.courseMember.visibility = View.GONE
-            holder.tvTimeCreate.visibility = View.GONE
-            holder.btnJoin.visibility = View.GONE
-            holder.courseStatus.visibility = View.VISIBLE
-            holder.tvTime.visibility = View.VISIBLE
+            holder.tvMember.visibility = View.GONE
         }
+
+        holder.courseMember.visibility = View.GONE
+        holder.tvTimeCreate.visibility = View.GONE
+        holder.btnJoin.visibility = View.GONE
+        holder.courseStatus.visibility = View.VISIBLE
+        holder.tvTime.visibility = View.VISIBLE
     }
 
+    holder.itemView.setOnClickListener { onItemClick?.invoke(room) }
+}
 
-    override fun getItemCount(): Int = roomList.size
 
-    fun updateData(newList: List<Room>) {
-        roomList = newList
-        notifyDataSetChanged()
-    }
+override fun getItemCount(): Int = roomList.size
+
+fun updateData(newList: List<Room>) {
+    roomList = newList
+    notifyDataSetChanged()
+}
 }

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/api/ApiConfig.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/api/ApiConfig.kt
@@ -13,6 +13,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 object ApiConfig {
     // Thay đổi BASE_URL tại đây
+    // Deploy: https://study-group-chat.onrender.com/
     private const val BASE_URL = "https://study-group-chat.onrender.com/"
 
     private val loggingInterceptor = HttpLoggingInterceptor().apply {

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/api/RoomApiService.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/api/RoomApiService.kt
@@ -29,8 +29,16 @@ interface RoomApiService {
     @GET("api/rooms/{roomId}")
     suspend fun getRoom(@Path("roomId") roomId: String): Response<Room>
 
+    @Multipart
     @PUT("api/rooms/{roomId}")
-    suspend fun updateRoom(@Path("roomId") roomId: String, @Body request: CreateRoomRequest): Response<Room>
+    suspend fun updateRoom(
+        @Path("roomId") roomId: String,
+        @Part avatar: MultipartBody.Part?,
+        @Part("room_name") roomName: RequestBody?,
+        @Part("description") description: RequestBody?,
+        @Part("room_mode") roomMode: RequestBody?,
+        @Part("expired_at") expiredAt: RequestBody?
+    ): Response<Room>
 
     @DELETE("api/rooms/{roomId}")
     suspend fun deleteRoom(@Path("roomId") roomId: String): Response<Unit>

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/repository/RoomRepository.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/repository/RoomRepository.kt
@@ -3,10 +3,13 @@ package com.example.studygroupchat.repository
 import com.example.studygroupchat.api.RoomApiService
 import com.example.studygroupchat.data.local.RoomDao
 import com.example.studygroupchat.data.local.RoomEntity
+import com.example.studygroupchat.model.room.CreateRoomRequest
 import com.example.studygroupchat.model.room.Room
 import com.example.studygroupchat.model.user.User
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 
 class RoomRepository(
     private val apiService: RoomApiService,
@@ -75,6 +78,35 @@ class RoomRepository(
             Result.failure(e)
         }
     }
+
+    suspend fun updateRoom(
+        roomId: String,
+        file: MultipartBody.Part?,
+        name: RequestBody?,
+        description: RequestBody?,
+        mode: RequestBody?,
+        expiredAt: RequestBody?
+    ): Result<Room> = withContext(Dispatchers.IO) {
+        try {
+            val response = apiService.updateRoom(
+                roomId,
+                file,
+                name,
+                description,
+                mode,
+                expiredAt
+            )
+            if (response.isSuccessful) {
+                response.body()?.let { Result.success(it) }
+                    ?: Result.failure(Exception("Empty response body"))
+            } else {
+                Result.failure(Exception("Failed to update room: ${'$'}{response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
 
     suspend fun getCachedRooms(): List<Room> = withContext(Dispatchers.IO) {
         roomDao.getRooms().map { it.toModel() }

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/CreateRoomFragment.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/CreateRoomFragment.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.lifecycleScope
 import com.example.studygroupchat.R
 import com.example.studygroupchat.api.ApiConfig
 import com.example.studygroupchat.databinding.FragmentCreateRoomBinding
+import com.example.studygroupchat.ui.fragments.GroupDetailFragment
 import com.example.studygroupchat.viewmodel.CreateRoomViewModel
 import com.example.studygroupchat.viewmodel.CreateRoomViewModelFactory
 import kotlinx.coroutines.launch
@@ -170,7 +171,17 @@ class CreateRoomFragment : Fragment() {
                 result.fold(
                     onSuccess = { room ->
                         Toast.makeText(requireContext(), "Tạo phòng thành công", Toast.LENGTH_SHORT).show()
-                        requireActivity().onBackPressed()
+                        val fragment = GroupDetailFragment().apply {
+                            arguments = Bundle().apply {
+                                putSerializable("room", room)
+                                putString("roomId", room.roomId.toString())
+                                putBoolean("isOwner", true)
+                            }
+                        }
+                        parentFragmentManager.beginTransaction()
+                            .replace(R.id.fragment_container, fragment)
+                            .addToBackStack(null)
+                            .commit()
                     },
                     onFailure = { error ->
                         Toast.makeText(requireContext(), "Vui lòng kiểm tra mạng hoặc server không sẵn sàng.", Toast.LENGTH_SHORT).show()

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/GroupDetailFragment.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/GroupDetailFragment.kt
@@ -17,6 +17,7 @@ import com.example.studygroupchat.adapter.MemberAdapter
 import com.example.studygroupchat.model.room.Room
 import com.example.studygroupchat.model.room.RoomMember
 import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -38,18 +39,22 @@ class GroupDetailFragment : Fragment() {
         toolbar.title = "Chi tiết nhóm"
 
         toolbar.setNavigationOnClickListener {
-            // Quay lại Fragment trước đó
-            parentFragmentManager.popBackStack()
+            navigateHome()
         }
 
-        toolbar.inflateMenu(R.menu.toolbar_menu)
+        val room = arguments?.getSerializable("room") as? Room
+        val isOwner = arguments?.getBoolean("isOwner", false) == true
+        if (isOwner) {
+            toolbar.inflateMenu(R.menu.toolbar_menu)
+        }
 
         toolbar.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
                 R.id.menu_members -> {
                     val fragment = GroupManagerFragment()
+                    fragment.arguments = Bundle().apply { putSerializable("room", room) }
                     parentFragmentManager.beginTransaction()
-                        .replace(R.id.fragment_container, fragment) // container ID trong Activity
+                        .replace(R.id.fragment_container, fragment)
                         .addToBackStack(null)
                         .commit()
                     true
@@ -59,7 +64,6 @@ class GroupDetailFragment : Fragment() {
         }
 
 
-        val room = arguments?.getSerializable("room") as? Room
         if (room == null) {
             Toast.makeText(requireContext(), "Không tìm thấy thông tin nhóm", Toast.LENGTH_SHORT).show()
             parentFragmentManager.popBackStack()
@@ -109,6 +113,17 @@ class GroupDetailFragment : Fragment() {
 
             recyclerViewMember.adapter = adapter
             recyclerViewMember.layoutManager = LinearLayoutManager(requireContext())
+
+            val shareButton = view.findViewById<MaterialButton>(R.id.shareGroup)
+            shareButton.setOnClickListener {
+                val fragment = ShareRoomFragment().apply {
+                    arguments = Bundle().apply { putSerializable("room", r) }
+                }
+                parentFragmentManager.beginTransaction()
+                    .replace(R.id.fragment_container, fragment)
+                    .addToBackStack(null)
+                    .commit()
+            }
         }
 
     }
@@ -122,6 +137,13 @@ class GroupDetailFragment : Fragment() {
         } catch (e: Exception) {
             "Không rõ"
         }
+    }
+
+    private fun navigateHome() {
+        parentFragmentManager.popBackStack(null, androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, HomeFragment())
+            .commit()
     }
 
 //    private fun showMemberOptions(member: RoomMember) {

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/GroupManagerFragment.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/GroupManagerFragment.kt
@@ -1,60 +1,202 @@
 package com.example.studygroupchat.ui.fragments
 
+import android.app.DatePickerDialog
+import android.net.Uri
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.TextView
+import android.widget.RadioButton
+import android.widget.Toast
+import android.widget.ImageView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.example.studygroupchat.R
+import com.example.studygroupchat.StudyGroupChatApplication
+import com.example.studygroupchat.api.ApiConfig
+import com.example.studygroupchat.model.room.Room
+import com.example.studygroupchat.repository.RoomRepository
+import com.example.studygroupchat.viewmodel.ManageRoomViewModel
+import com.example.studygroupchat.viewmodel.ManageRoomViewModelFactory
+import com.google.android.material.appbar.MaterialToolbar
+import com.bumptech.glide.Glide
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [GroupManagerFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class GroupManagerFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    private lateinit var editName: EditText
+    private lateinit var editDescription: EditText
+    private lateinit var radioPublic: RadioButton
+    private lateinit var radioPrivate: RadioButton
+    private lateinit var imgAvatar: ImageView
+    private lateinit var imgChange: ImageView
+    private var selectedPart: MultipartBody.Part? = null
+    private lateinit var tvExpireDate: TextView
+    private lateinit var btnExtend: TextView
+    private var selectedDate: Date? = null
+
+    private val pickImageLauncher =
+        registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+            uri?.let { handleImageSelected(it) }
         }
+
+    private val viewModel: ManageRoomViewModel by viewModels {
+        val app = requireActivity().application as StudyGroupChatApplication
+        ManageRoomViewModelFactory(
+            RoomRepository(
+                ApiConfig.roomApiService,
+                app.database.roomDao()
+            )
+        )
     }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
+    ): View {
         return inflater.inflate(R.layout.fragment_group_manager, container, false)
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment GroupManagerFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            GroupManagerFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val toolbar = view.findViewById<MaterialToolbar>(R.id.toolbar)
+        toolbar.setNavigationIcon(R.drawable.ic_arrow_left)
+        toolbar.title = "Quản lý nhóm"
+        toolbar.inflateMenu(R.menu.menu_group_manager)
+        toolbar.setNavigationOnClickListener { parentFragmentManager.popBackStack() }
+
+        editName = view.findViewById(R.id.editGroupName)
+        editDescription = view.findViewById(R.id.editDescription)
+        radioPublic = view.findViewById(R.id.radioPublic)
+        radioPrivate = view.findViewById(R.id.radioPrivate)
+        imgAvatar = view.findViewById(R.id.imgRoomAvatar)
+        imgChange = view.findViewById(R.id.imgChangeAvatar)
+        tvExpireDate = view.findViewById(R.id.tvExpireDate)
+        btnExtend = view.findViewById(R.id.btnExtend)
+        val tvType = view.findViewById<TextView>(R.id.tvTypeGroup)
+        val tvMember = view.findViewById<TextView>(R.id.tvTotalMember)
+
+        val room = arguments?.getSerializable("room") as? Room
+        if (room != null) {
+            editName.setText(room.roomName)
+            editDescription.setText(room.description)
+            when (room.roomMode) {
+                "public" -> radioPublic.isChecked = true
+                "private" -> radioPrivate.isChecked = true
             }
+            tvType.text = if (room.roomMode == "public") "Nhóm công khai" else "Nhóm riêng tư"
+            tvMember.text = room.members?.size?.toString() ?: "0"
+            room.avatarUrl?.let {
+                Glide.with(this)
+                    .load(it)
+                    .placeholder(R.drawable.baseline_groups_24)
+                    .into(imgAvatar)
+            }
+            selectedDate = parseApiDate(room.expiredAt)
+            updateDateDisplay()
+        }
+
+        imgAvatar.setOnClickListener { pickImageLauncher.launch("image/*") }
+        imgChange.setOnClickListener { pickImageLauncher.launch("image/*") }
+
+        radioPublic.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                radioPrivate.isChecked = false
+                tvType.text = "Nhóm công khai"
+            }
+        }
+        radioPrivate.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                radioPublic.isChecked = false
+                tvType.text = "Nhóm riêng tư"
+            }
+        }
+
+        btnExtend.setOnClickListener { showDatePicker() }
+        tvExpireDate.setOnClickListener { showDatePicker() }
+
+        toolbar.setOnMenuItemClickListener {
+            if (it.itemId == R.id.action_save) {
+                val id = room?.roomId?.toString() ?: return@setOnMenuItemClickListener true
+                val mode = if (radioPublic.isChecked) "public" else "private"
+                val expired = selectedDate?.let { formatDateForApi(it) } ?: room?.expiredAt
+                viewModel.updateRoom(
+                    id,
+                    selectedPart,
+                    editName.text.toString(),
+                    editDescription.text.toString(),
+                    mode,
+                    expired
+                )
+                true
+            } else {
+                false
+            }
+        }
+
+        viewModel.updateResult.observe(viewLifecycleOwner) { result ->
+            result.onSuccess {
+                Toast.makeText(requireContext(), "Đã cập nhật nhóm", Toast.LENGTH_SHORT).show()
+                parentFragmentManager.popBackStack()
+            }
+            result.onFailure {
+                Toast.makeText(requireContext(), "Cập nhật thất bại", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun handleImageSelected(uri: Uri) {
+        imgAvatar.setImageURI(uri)
+        val file = File(requireContext().cacheDir, "room_avatar")
+        val input = requireContext().contentResolver.openInputStream(uri)
+        file.outputStream().use { out ->
+            input?.copyTo(out)
+        }
+        val requestBody = file.asRequestBody("image/*".toMediaTypeOrNull())
+        selectedPart = MultipartBody.Part.createFormData("avatar", file.name, requestBody)
+    }
+
+    private fun showDatePicker() {
+        val calendar = Calendar.getInstance()
+        selectedDate?.let { calendar.time = it }
+        val year = calendar.get(Calendar.YEAR)
+        val month = calendar.get(Calendar.MONTH)
+        val day = calendar.get(Calendar.DAY_OF_MONTH)
+        DatePickerDialog(requireContext(), { _, y, m, d ->
+            calendar.set(y, m, d)
+            selectedDate = calendar.time
+            updateDateDisplay()
+        }, year, month, day).show()
+    }
+
+    private fun updateDateDisplay() {
+        selectedDate?.let { date ->
+            val displayFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+            tvExpireDate.text = "Nhóm sẽ hết hạn vào ${displayFormat.format(date)}"
+        }
+    }
+
+    private fun parseApiDate(raw: String?): Date? {
+        if (raw.isNullOrBlank()) return null
+        return try {
+            val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault())
+            format.parse(raw)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun formatDateForApi(date: Date): String {
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault())
+        return format.format(date)
     }
 }

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/JoinRoomFragment.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/JoinRoomFragment.kt
@@ -8,9 +8,12 @@ import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.ProgressBar
 import android.widget.Toast
+import android.net.Uri
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
 import com.example.studygroupchat.R
 import com.example.studygroupchat.adapter.RoomAdapter
 import com.example.studygroupchat.api.ApiConfig
@@ -18,14 +21,31 @@ import com.example.studygroupchat.repository.RoomRepository
 import com.example.studygroupchat.StudyGroupChatApplication
 import com.example.studygroupchat.viewmodel.RoomViewModel
 import com.example.studygroupchat.viewmodel.RoomViewModelFactory
+import com.example.studygroupchat.ui.fragments.GroupDetailFragment
 import com.google.android.material.button.MaterialButton
 
 class JoinRoomFragment : Fragment() {
+
+    private var inviteCodeArg: String? = null
 
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: RoomAdapter
     private lateinit var progressBar: ProgressBar
     private lateinit var editCodeRoom: EditText
+    private lateinit var btnQR: MaterialButton
+
+    private val scanLauncher = registerForActivityResult(ScanContract()) { result ->
+        if (result.contents != null) {
+            val contents = result.contents
+            val code = if (contents.startsWith("studygroupchat://")) {
+                Uri.parse(contents).getQueryParameter("code")
+            } else contents
+            code?.let {
+                editCodeRoom.setText(it)
+                viewModel.joinRoom(it)
+            }
+        }
+    }
     private val viewModel: RoomViewModel by viewModels {
         val app = requireActivity().application as StudyGroupChatApplication
         RoomViewModelFactory(
@@ -34,6 +54,11 @@ class JoinRoomFragment : Fragment() {
                 app.database.roomDao()
             )
         )
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        inviteCodeArg = arguments?.getString(ARG_INVITE_CODE)
     }
 
     override fun onCreateView(
@@ -48,12 +73,20 @@ class JoinRoomFragment : Fragment() {
         progressBar = view.findViewById(R.id.progressBar)
         editCodeRoom = view.findViewById(R.id.editcodeRoom)
         val btnJoin = view.findViewById<MaterialButton>(R.id.btnJoin)
+        btnQR = view.findViewById(R.id.btnQR)
 
-        adapter = RoomAdapter(emptyList(), isJoinRoom = true) { room ->
-            room.inviteCode?.let { viewModel.joinRoom(it) }
-        }
+        adapter = RoomAdapter(
+            emptyList(),
+            isJoinRoom = true,
+            onJoinClick = { room -> room.inviteCode?.let { viewModel.joinRoom(it) } }
+        )
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = adapter
+
+        inviteCodeArg?.let {
+            editCodeRoom.setText(it)
+            viewModel.joinRoom(it)
+        }
 
         btnJoin.setOnClickListener {
             val code = editCodeRoom.text.toString().trim()
@@ -64,16 +97,41 @@ class JoinRoomFragment : Fragment() {
             }
         }
 
+        btnQR.setOnClickListener {
+            val options = ScanOptions()
+            options.setPrompt(getString(R.string.scan_qr_prompt))
+            options.setBeepEnabled(false)
+            options.setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+            scanLauncher.launch(options)
+        }
+
         viewModel.rooms.observe(viewLifecycleOwner) { adapter.updateData(it) }
         viewModel.isLoading.observe(viewLifecycleOwner) { progressBar.visibility = if (it) View.VISIBLE else View.GONE }
         viewModel.joinResult.observe(viewLifecycleOwner) { result ->
             result.onSuccess {
                 Toast.makeText(requireContext(), "Tham gia phòng thành công", Toast.LENGTH_SHORT).show()
+                val fragment = GroupDetailFragment().apply {
+                    arguments = Bundle().apply {
+                        putSerializable("room", it)
+                        putString("roomId", it.roomId.toString())
+                    }
+                }
+                parentFragmentManager.beginTransaction()
+                    .replace(R.id.fragment_container, fragment)
+                    .addToBackStack(null)
+                    .commit()
             }.onFailure {
                 Toast.makeText(requireContext(), "Không thể tham gia phòng", Toast.LENGTH_SHORT).show()
             }
         }
 
         viewModel.fetchPublicRooms()
+    }
+
+    companion object {
+        private const val ARG_INVITE_CODE = "invite_code"
+        fun newInstance(code: String) = JoinRoomFragment().apply {
+            arguments = Bundle().apply { putString(ARG_INVITE_CODE, code) }
+        }
     }
 }

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/ShareRoomFragment.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/ShareRoomFragment.kt
@@ -1,60 +1,70 @@
 package com.example.studygroupchat.ui.fragments
 
+import android.graphics.Bitmap
+import android.graphics.Color
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
 import com.example.studygroupchat.R
+import com.example.studygroupchat.model.room.Room
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [ShareRoomFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class ShareRoomFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
+    private var room: Room? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
-        }
+        room = arguments?.getSerializable(ARG_ROOM) as? Room
     }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View? {
-        // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_share_room, container, false)
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ShareRoomFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            ShareRoomFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val toolbar = view.findViewById<MaterialToolbar>(R.id.toolbarShareLinkRoom)
+        toolbar.setNavigationIcon(R.drawable.ic_arrow_left)
+        toolbar.setNavigationOnClickListener { parentFragmentManager.popBackStack() }
+
+        room?.let { r ->
+            view.findViewById<TextView>(R.id.tvGroupTitle).text = r.roomName
+            view.findViewById<TextView>(R.id.tvGroupCode).text = r.inviteCode ?: ""
+            r.inviteCode?.let { code ->
+                val link = "studygroupchat://join?code=$code"
+                val bitmap = generateQrBitmap(link)
+                view.findViewById<ImageView>(R.id.imgQRCode).setImageBitmap(bitmap)
             }
+        }
+    }
+
+    private fun generateQrBitmap(content: String): Bitmap {
+        val writer = QRCodeWriter()
+        val bitMatrix = writer.encode(content, BarcodeFormat.QR_CODE, 400, 400)
+        val width = bitMatrix.width
+        val height = bitMatrix.height
+        val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565)
+        for (x in 0 until width) {
+            for (y in 0 until height) {
+                bmp.setPixel(x, y, if (bitMatrix[x, y]) Color.BLACK else Color.WHITE)
+            }
+        }
+        return bmp
+    }
+
+    companion object {
+        private const val ARG_ROOM = "room"
+        fun newInstance(room: Room) = ShareRoomFragment().apply {
+            arguments = Bundle().apply { putSerializable(ARG_ROOM, room) }
+        }
     }
 }

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/viewmodel/ManageRoomViewModel.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/viewmodel/ManageRoomViewModel.kt
@@ -1,0 +1,56 @@
+package com.example.studygroupchat.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.studygroupchat.model.room.Room
+import com.example.studygroupchat.repository.RoomRepository
+import kotlinx.coroutines.launch
+import okhttp3.MultipartBody
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody.Companion.toRequestBody
+
+class ManageRoomViewModel(private val repository: RoomRepository) : ViewModel() {
+    private val _room = MutableLiveData<Room>()
+    val room: LiveData<Room> = _room
+
+    private val _updateResult = MutableLiveData<Result<Room>>()
+    val updateResult: LiveData<Result<Room>> = _updateResult
+
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> = _isLoading
+
+    fun fetchRoom(roomId: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            val result = repository.getRoom(roomId)
+            result.onSuccess { _room.value = it }
+            _isLoading.value = false
+        }
+    }
+
+    fun updateRoom(
+        roomId: String,
+        file: MultipartBody.Part?,
+        name: String?,
+        description: String?,
+        mode: String?,
+        expiredAt: String?
+    ) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            val result = repository.updateRoom(
+                roomId,
+                file,
+                name?.toRequestBody("text/plain".toMediaTypeOrNull()),
+                description?.toRequestBody("text/plain".toMediaTypeOrNull()),
+                mode?.toRequestBody("text/plain".toMediaTypeOrNull()),
+                expiredAt?.toRequestBody("text/plain".toMediaTypeOrNull())
+            )
+            result.onSuccess { _room.value = it }
+            _updateResult.value = result
+            _isLoading.value = false
+        }
+    }
+}

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/viewmodel/ManageRoomViewModelFactory.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/viewmodel/ManageRoomViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.example.studygroupchat.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.studygroupchat.repository.RoomRepository
+
+class ManageRoomViewModelFactory(private val repository: RoomRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ManageRoomViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return ManageRoomViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/StudyGroupChat/app/src/main/res/layout/fragment_group_detail.xml
+++ b/StudyGroupChat/app/src/main/res/layout/fragment_group_detail.xml
@@ -11,7 +11,7 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
         <!-- Toolbar -->
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbargroudDetail"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -24,10 +24,10 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fillViewport="true">
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
                 <!-- Ảnh đại diện nhóm -->
                 <ImageView
@@ -131,31 +131,31 @@
                     </LinearLayout>
 
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:paddingHorizontal="15dp"
-                        android:layout_marginTop="5dp">
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/shareGroup"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:text="Link nhóm"
-                            android:layout_marginRight="10dp"
-                            android:textAllCaps="false"
-                            android:textColor="#3B82F6"
-                            android:layout_weight="1"
-                            android:textSize="14sp"
-                            app:icon="@drawable/outline_link_24"
-                            app:iconTint="#3B82F6"
-                            app:iconGravity="textStart"
-                            app:iconPadding="10dp"
-                            app:cornerRadius="12dp"
-                            app:strokeWidth="1dp"
-                            app:strokeColor="#A4C4FA"
-                            android:backgroundTint="#EFF6FF"
-                            android:paddingVertical="10dp"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingHorizontal="15dp"
+            android:layout_marginTop="5dp">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/shareGroup"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="Mã QR"
+                android:layout_marginRight="10dp"
+                android:textAllCaps="false"
+                android:textColor="#3B82F6"
+                android:layout_weight="1"
+                android:textSize="14sp"
+                app:icon="@drawable/baseline_qr_code_scanner_24"
+                app:iconTint="#3B82F6"
+                app:iconGravity="textStart"
+                app:iconPadding="10dp"
+                app:cornerRadius="12dp"
+                app:strokeWidth="1dp"
+                app:strokeColor="#A4C4FA"
+                android:backgroundTint="#EFF6FF"
+                android:paddingVertical="10dp"/>
 
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/leavetheGroup"

--- a/StudyGroupChat/app/src/main/res/layout/fragment_group_manager.xml
+++ b/StudyGroupChat/app/src/main/res/layout/fragment_group_manager.xml
@@ -10,7 +10,7 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
         <!--     App bar -->
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -38,6 +38,7 @@
                     android:layout_marginBottom="16dp">
 
                     <ImageView
+                        android:id="@+id/imgRoomAvatar"
                         android:layout_width="90dp"
                         android:layout_height="90dp"
                         android:layout_gravity="center"
@@ -47,6 +48,7 @@
                         android:scaleType="centerCrop" />
 
                     <ImageView
+                        android:id="@+id/imgChangeAvatar"
                         android:layout_width="24dp"
                         android:layout_height="24dp"
                         android:layout_gravity="bottom|end"
@@ -66,10 +68,11 @@
                     >
 
                     <EditText
+                        android:id="@+id/editGroupName"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Web"
                         android:background="@null"
+                        android:hint="Tên nhóm"
                         android:textSize="20sp"
                         android:textStyle="bold" />
 
@@ -114,6 +117,25 @@
                         android:textColor="#4D4D4D"/>
                 </LinearLayout>
 
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="Giới thiệu"
+                    android:textStyle="bold"/>
+
+                <EditText
+                    android:id="@+id/editDescription"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:background="@drawable/bg_edittext"
+                    android:hint="Giới thiệu về nhóm"
+                    android:inputType="textMultiLine"
+                    android:minLines="3"
+                    android:padding="8dp"
+                    android:gravity="top" />
+
                 <!-- Quản lý nhóm -->
                 <TextView
                     android:layout_height="wrap_content"
@@ -124,6 +146,7 @@
                     android:layout_marginBottom="8dp" />
 
                 <LinearLayout
+                    android:id="@+id/layoutExtend"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
@@ -153,6 +176,7 @@
                             android:layout_height="wrap_content" />
 
                         <TextView
+                            android:id="@+id/tvExpireDate"
                             android:text="Nhóm sẽ hết hạn vào 15/12/2024"
                             android:textSize="12sp"
                             android:textColor="#666"
@@ -161,6 +185,7 @@
                     </LinearLayout>
 
                     <TextView
+                        android:id="@+id/btnExtend"
                         android:layout_height="wrap_content"
                         android:layout_width="wrap_content"
                         android:text="Gia hạn"
@@ -239,7 +264,7 @@
                                 android:id="@+id/radioPublic"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:checked="true" />
+                                />
                             <LinearLayout
                                 android:layout_width="0dp"
                                 android:layout_height="wrap_content"

--- a/StudyGroupChat/app/src/main/res/layout/fragment_share_room.xml
+++ b/StudyGroupChat/app/src/main/res/layout/fragment_share_room.xml
@@ -5,17 +5,15 @@
     android:layout_height="match_parent"
     tools:context=".ui.fragments.ShareRoomFragment">
 
-    <?xml version="1.0" encoding="utf-8"?>
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
-        <Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbarShareLinkRoom"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@drawable/background_root"
-            />
+            android:background="@drawable/background_root" />
         <LinearLayout
             android:id="@+id/layout_group_invite"
             android:layout_width="match_parent"

--- a/StudyGroupChat/app/src/main/res/menu/menu_group_manager.xml
+++ b/StudyGroupChat/app/src/main/res/menu/menu_group_manager.xml
@@ -1,0 +1,6 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_save"
+        android:title="Lưu"
+        android:showAsAction="ifRoom" />
+</menu>

--- a/StudyGroupChat/app/src/main/res/values/strings.xml
+++ b/StudyGroupChat/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">Study Group Chat</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="scan_qr_prompt">Quét mã QR</string>
 </resources>


### PR DESCRIPTION
This commit introduces several enhancements to group management and sharing functionalities:

- **Group Management:**
    - Implemented `GroupManagerFragment` for editing group details (name, description, mode, avatar, expiration date).
    - Added `ManageRoomViewModel` and `ManageRoomViewModelFactory` to handle room update logic.
    - Updated `RoomRepository` with an `updateRoom` function to send multipart/form-data requests.
    - Added a "Save" option to the `GroupManagerFragment` toolbar (`menu_group_manager.xml`).
    - Backend API (`/api/rooms/{room_id}`) now supports updating room avatar and other fields via multipart/form-data.
    - Navigating to `GroupDetailFragment` now passes an `isOwner` flag.
    - After creating a room, users are now navigated to the `GroupDetailFragment`.

- **Group Sharing & Joining:**
    - Changed "Link nhóm" button text to "Mã QR" in `fragment_group_detail.xml`.
    - Implemented `ShareRoomFragment` to display the group's QR code (generated from `studygroupchat://join?code={inviteCode}`).
    - Added QR code scanning functionality to `JoinRoomFragment` using `zxing-android-embedded`.
    - `JoinRoomFragment` can now be instantiated with an invite code, allowing deeplinking.
    - Added intent filter to `MainActivity` to handle `studygroupchat://join` deeplinks.
    - After joining a room, users are now navigated to the `GroupDetailFragment`.

- **UI & Navigation:**
    - `GroupDetailFragment` toolbar now shows management options only for group owners.
    - Pressing back from `GroupDetailFragment` now navigates to the `HomeFragment`.
    - Clicking a room item in `HomeFragment` now navigates to `GroupDetailFragment`.
    - `MainActivity` now hides the bottom navigation bar for full-screen fragments like `GroupDetailFragment` and `GroupManagerFragment`.

- **Other:**
    - Added `CAMERA` permission to `AndroidManifest.xml`.
    - `HomeFragment` now fetches the current user's ID to determine room ownership.
    - Updated API base URL in `ApiConfig.kt`.