### PR TITLE
Implement leave/delete room feature

### DIFF
--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/api/RoomApiService.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/api/RoomApiService.kt
@@ -46,6 +46,9 @@ interface RoomApiService {
     @POST("api/rooms/join")
     suspend fun joinRoom(@Body request: Map<String, String>): Response<JoinRoomResponse>
 
+    @POST("api/rooms/{roomId}/leave")
+    suspend fun leaveRoom(@Path("roomId") roomId: String): Response<Unit>
+
     @GET("api/rooms/{roomId}/members")
     suspend fun getRoomMembers(@Path("roomId") roomId: String): Response<List<RoomMember>>
 

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/EditProfileFragment.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/EditProfileFragment.kt
@@ -83,6 +83,25 @@ class EditProfileFragment : Fragment() {
                 fragment.changePassword()
             }
         }
+        userViewModel.updateResult.observe(viewLifecycleOwner) { result ->
+            result.onSuccess {
+                android.widget.Toast.makeText(requireContext(), "\u0110\u00E3 c\u1EADp nh\u1EADt h\u1ED3 s\u01A1", android.widget.Toast.LENGTH_SHORT).show()
+                parentFragmentManager.popBackStack()
+            }
+            result.onFailure {
+                android.widget.Toast.makeText(requireContext(), "C\u1EADp nh\u1EADt th\u1EA5t b\u1EA1i", android.widget.Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        userViewModel.passwordResult.observe(viewLifecycleOwner) { result ->
+            result.onSuccess {
+                android.widget.Toast.makeText(requireContext(), "\u0110\u00E3 c\u1EADp nh\u1EADt m\u1EADt kh\u1EA9u", android.widget.Toast.LENGTH_SHORT).show()
+                parentFragmentManager.popBackStack()
+            }
+            result.onFailure {
+                android.widget.Toast.makeText(requireContext(), "C\u1EADp nh\u1EADt th\u1EA5t b\u1EA1i", android.widget.Toast.LENGTH_SHORT).show()
+            }
+        }
     }
     private fun handleCancel() {
         //quay về màn hình trước đó trong Navigation component

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/GroupManagerFragment.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/ui/fragments/GroupManagerFragment.kt
@@ -125,21 +125,27 @@ class GroupManagerFragment : Fragment() {
         tvExpireDate.setOnClickListener { showDatePicker() }
 
         toolbar.setOnMenuItemClickListener {
-            if (it.itemId == R.id.action_save) {
-                val id = room?.roomId?.toString() ?: return@setOnMenuItemClickListener true
-                val mode = if (radioPublic.isChecked) "public" else "private"
-                val expired = selectedDate?.let { formatDateForApi(it) } ?: room?.expiredAt
-                viewModel.updateRoom(
-                    id,
-                    selectedPart,
-                    editName.text.toString(),
-                    editDescription.text.toString(),
-                    mode,
-                    expired
-                )
-                true
-            } else {
-                false
+            when (it.itemId) {
+                R.id.action_save -> {
+                    val id = room?.roomId?.toString() ?: return@setOnMenuItemClickListener true
+                    val mode = if (radioPublic.isChecked) "public" else "private"
+                    val expired = selectedDate?.let { formatDateForApi(it) } ?: room?.expiredAt
+                    viewModel.updateRoom(
+                        id,
+                        selectedPart,
+                        editName.text.toString(),
+                        editDescription.text.toString(),
+                        mode,
+                        expired
+                    )
+                    true
+                }
+                R.id.action_delete -> {
+                    val id = room?.roomId?.toString() ?: return@setOnMenuItemClickListener true
+                    viewModel.deleteRoom(id)
+                    true
+                }
+                else -> false
             }
         }
 
@@ -150,6 +156,16 @@ class GroupManagerFragment : Fragment() {
             }
             result.onFailure {
                 Toast.makeText(requireContext(), "Cập nhật thất bại", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        viewModel.deleteResult.observe(viewLifecycleOwner) { result ->
+            result.onSuccess {
+                Toast.makeText(requireContext(), "Đã xoá nhóm", Toast.LENGTH_SHORT).show()
+                navigateHome()
+            }
+            result.onFailure {
+                Toast.makeText(requireContext(), "Xoá nhóm thất bại", Toast.LENGTH_SHORT).show()
             }
         }
     }
@@ -198,5 +214,12 @@ class GroupManagerFragment : Fragment() {
     private fun formatDateForApi(date: Date): String {
         val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault())
         return format.format(date)
+    }
+
+    private fun navigateHome() {
+        parentFragmentManager.popBackStack(null, androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, HomeFragment())
+            .commit()
     }
 }

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/viewmodel/ManageRoomViewModel.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/viewmodel/ManageRoomViewModel.kt
@@ -21,6 +21,9 @@ class ManageRoomViewModel(private val repository: RoomRepository) : ViewModel() 
     private val _isLoading = MutableLiveData<Boolean>()
     val isLoading: LiveData<Boolean> = _isLoading
 
+    private val _deleteResult = MutableLiveData<Result<Unit>>()
+    val deleteResult: LiveData<Result<Unit>> = _deleteResult
+
     fun fetchRoom(roomId: String) {
         viewModelScope.launch {
             _isLoading.value = true
@@ -50,6 +53,15 @@ class ManageRoomViewModel(private val repository: RoomRepository) : ViewModel() 
             )
             result.onSuccess { _room.value = it }
             _updateResult.value = result
+            _isLoading.value = false
+        }
+    }
+
+    fun deleteRoom(roomId: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            val result = repository.deleteRoom(roomId)
+            _deleteResult.value = result
             _isLoading.value = false
         }
     }

--- a/StudyGroupChat/app/src/main/java/com/example/studygroupchat/viewmodel/RoomViewModel.kt
+++ b/StudyGroupChat/app/src/main/java/com/example/studygroupchat/viewmodel/RoomViewModel.kt
@@ -18,6 +18,9 @@ class RoomViewModel(private val repository: RoomRepository) : ViewModel() {
     private val _joinResult = MutableLiveData<Result<Room>>()
     val joinResult: LiveData<Result<Room>> = _joinResult
 
+    private val _leaveResult = MutableLiveData<Result<Unit>>()
+    val leaveResult: LiveData<Result<Unit>> = _leaveResult
+
     private val _selectedRoom = MutableLiveData<Result<Room>>()
     val selectedRoom: LiveData<Result<Room>> = _selectedRoom
 
@@ -58,6 +61,18 @@ class RoomViewModel(private val repository: RoomRepository) : ViewModel() {
             _joinResult.value = result
             if (result.isSuccess) {
                 fetchPublicRooms()
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun leaveRoom(roomId: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            val result = repository.leaveRoom(roomId)
+            _leaveResult.value = result
+            if (result.isSuccess) {
+                fetchMyRooms()
             }
             _isLoading.value = false
         }

--- a/StudyGroupChat/app/src/main/res/menu/menu_group_manager.xml
+++ b/StudyGroupChat/app/src/main/res/menu/menu_group_manager.xml
@@ -3,4 +3,9 @@
         android:id="@+id/action_save"
         android:title="Lưu"
         android:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_delete"
+        android:title="Xóa nhóm"
+        android:showAsAction="never" />
 </menu>


### PR DESCRIPTION
This commit introduces the ability for users to leave or delete study groups.

Key changes include:

- **RoomViewModel:** Added `leaveResult` LiveData and `leaveRoom` function.
- **RoomRepository:** Implemented `leaveRoom` and `deleteRoom` suspend functions to interact with the API.
- **GroupManagerFragment:** Added a "Delete Group" option to the menu and implemented the deletion logic.
- **EditProfileFragment:** Observed `updateResult` and `passwordResult` to provide user feedback on profile updates.
- **ManageRoomViewModel:** Added `deleteResult` LiveData and `deleteRoom` function.
- **Backend API (rooms.py):** Added a `/rooms/<room_id>/leave` endpoint for handling leave requests.
- **RoomApiService:** Included `leaveRoom` and `deleteRoom` methods.
- **GroupDetailFragment:** Implemented the "Leave Group" functionality and conditional visibility of the leave button based on ownership.
- **menu_group_manager.xml:** Added "Xóa nhóm" (Delete Group) menu item.

The `joinRoom` function in `RoomRepository` was also updated to handle cases where a user might already be a member of a room they are trying to join.